### PR TITLE
fix: Null attacker crash, unicode name support, scoreboard rank cache & virtual override via API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,4 @@ obj/
 # Shared API exports
 src-plugin/resources/exports/K4-LevelRanksSharedApi.dll
 src-plugin/K4-LevelRanks.csproj.user
-src-plugin/Properties/PublishProfiles/FolderProfile.pubxml
-src-plugin/Properties/PublishProfiles/FolderProfile.pubxml.user
+src-plugin/Properties/PublishProfiles/*

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ obj/
 
 # Shared API exports
 src-plugin/resources/exports/K4-LevelRanksSharedApi.dll
+src-plugin/K4-LevelRanks.csproj.user
+src-plugin/Properties/PublishProfiles/FolderProfile.pubxml
+src-plugin/Properties/PublishProfiles/FolderProfile.pubxml.user

--- a/src-plugin/K4-LevelRanks.csproj
+++ b/src-plugin/K4-LevelRanks.csproj
@@ -46,12 +46,21 @@
 		<TrimmerRootAssembly Remove="FluentMigrator.Runner.SqlServer" />
 	</ItemGroup>
 
+	<!-- Exclude runtime folders from publish -->
+	<ItemGroup>
+		<Content Include="$(PublishDir)runtimes\**" CopyToPublishDirectory="Never" />
+	</ItemGroup>
+
 	<Target Name="CopySharedApiToExports" AfterTargets="Build">
 		<Copy SourceFiles="$(MSBuildThisFileDirectory)../src-shared/build/$(TargetFramework)/K4-LevelRanksSharedApi.dll" DestinationFolder="$(MSBuildThisFileDirectory)resources/exports/" />
 	</Target>
 
 	<Target Name="CopySharedApiToPublish" AfterTargets="Publish">
 		<Copy SourceFiles="$(MSBuildThisFileDirectory)../src-shared/build/$(TargetFramework)/K4-LevelRanksSharedApi.dll" DestinationFolder="$(PublishDir)resources/exports/" />
+	</Target>
+
+	<Target Name="RemoveRuntimeFolders" AfterTargets="Publish">
+		<RemoveDir Directories="$(PublishDir)runtimes" />
 	</Target>
 
 	<Target Name="CreateZip" AfterTargets="CopySharedApiToPublish" DependsOnTargets="CopySharedApiToPublish">

--- a/src-plugin/Plugin/Commands/Commands.cs
+++ b/src-plugin/Plugin/Commands/Commands.cs
@@ -1,7 +1,6 @@
 using K4Ranks.Menus;
 using SwiftlyS2.Shared.Commands;
 using SwiftlyS2.Shared.Players;
-using SwiftlyS2.Shared.SteamAPI;
 
 namespace K4Ranks;
 
@@ -98,8 +97,8 @@ public sealed partial class Plugin
 		// Show player's position in chat
 		Task.Run(async () =>
 		{
-			var visibleSteamId = SteamIdParser.ToSteamId(player.SteamID);
-			var position = await Database.GetPlayerRankPositionAsync(visibleSteamId);
+			var steamId = player.SteamID.ToString();
+			var position = await Database.GetPlayerRankPositionAsync(steamId);
 			var totalPlayers = await Database.GetTotalPlayersAsync();
 
 			if (position > 0 && totalPlayers > 0)
@@ -136,8 +135,8 @@ public sealed partial class Plugin
 
 	private async Task ResetPlayerRankAsync(IPlayer player, PlayerData data)
 	{
-		var visibleSteamId = SteamIdParser.ToSteamId(player.SteamID);
-		await Database.ResetPlayerAsync(visibleSteamId);
+		var steamId = player.SteamID.ToString();
+		await Database.ResetPlayerAsync(steamId);
 
 		data.Reset(Config.CurrentValue.Rank.StartPoints);
 
@@ -200,8 +199,8 @@ public sealed partial class Plugin
 		// Show player's position in chat
 		Task.Run(async () =>
 		{
-			var visibleSteamId = SteamIdParser.ToSteamId(player.SteamID);
-			var position = await Database.GetPlayerRankPositionByTimeAsync(visibleSteamId);
+			var steamId = player.SteamID.ToString();
+			var position = await Database.GetPlayerRankPositionByTimeAsync(steamId);
 			var totalPlayers = await Database.GetTotalPlayersAsync();
 
 			if (position > 0 && totalPlayers > 0)

--- a/src-plugin/Plugin/Database/DatabaseService.HitStats.cs
+++ b/src-plugin/Plugin/Database/DatabaseService.HitStats.cs
@@ -18,7 +18,7 @@ public sealed partial class Plugin
 		// =           LOAD OPERATIONS
 		// =========================================
 
-		public async Task<HitData?> LoadHitDataAsync(string visibleSteamId)
+		public async Task<HitData?> LoadHitDataAsync(string steamId)
 		{
 			if (!IsEnabled || !_modules.HitStatsEnabled)
 				return null;
@@ -28,11 +28,11 @@ public sealed partial class Plugin
 				using var connection = Core.Database.GetConnection(_connectionName);
 				connection.Open();
 
-				return await connection.GetAsync<HitData>(visibleSteamId);
+				return await connection.GetAsync<HitData>(steamId);
 			}
 			catch (Exception ex)
 			{
-				Core.Logger.LogError(ex, "Failed to load hit data for {Steam}", visibleSteamId);
+				Core.Logger.LogError(ex, "Failed to load hit data for {Steam}", steamId);
 				return null;
 			}
 		}

--- a/src-plugin/Plugin/Database/DatabaseService.Player.cs
+++ b/src-plugin/Plugin/Database/DatabaseService.Player.cs
@@ -12,7 +12,7 @@ public sealed partial class Plugin
 		// =           LOAD OPERATIONS
 		// =========================================
 
-		public async Task<PlayerData?> LoadPlayerAsync(string visibleSteamId)
+		public async Task<PlayerData?> LoadPlayerAsync(string steamId)
 		{
 			if (!IsEnabled)
 				return null;
@@ -22,11 +22,11 @@ public sealed partial class Plugin
 				using var connection = Core.Database.GetConnection(_connectionName);
 				connection.Open();
 
-				return await connection.GetAsync<PlayerData>(visibleSteamId);
+				return await connection.GetAsync<PlayerData>(steamId);
 			}
 			catch (Exception ex)
 			{
-				Core.Logger.LogError(ex, "Failed to load player {Steam}", visibleSteamId);
+				Core.Logger.LogError(ex, "Failed to load player {Steam}", steamId);
 				return null;
 			}
 		}
@@ -106,7 +106,7 @@ public sealed partial class Plugin
 		// =           QUERY OPERATIONS
 		// =========================================
 
-		public async Task<int> GetPlayerRankPositionAsync(string visibleSteamId)
+		public async Task<int> GetPlayerRankPositionAsync(string steamId)
 		{
 			if (!IsEnabled)
 				return -1;
@@ -117,7 +117,7 @@ public sealed partial class Plugin
 				connection.Open();
 
 				// Get player's current value
-				var player = await connection.GetAsync<PlayerData>(visibleSteamId);
+				var player = await connection.GetAsync<PlayerData>(steamId);
 				if (player == null)
 					return -1;
 
@@ -127,12 +127,12 @@ public sealed partial class Plugin
 			}
 			catch (Exception ex)
 			{
-				Core.Logger.LogError(ex, "Failed to get rank position for {Steam}", visibleSteamId);
+				Core.Logger.LogError(ex, "Failed to get rank position for {Steam}", steamId);
 				return -1;
 			}
 		}
 
-		public async Task<int> GetPlayerRankPositionByTimeAsync(string visibleSteamId)
+		public async Task<int> GetPlayerRankPositionByTimeAsync(string steamId)
 		{
 			if (!IsEnabled)
 				return -1;
@@ -143,7 +143,7 @@ public sealed partial class Plugin
 				connection.Open();
 
 				// Get player's current playtime
-				var player = await connection.GetAsync<PlayerData>(visibleSteamId);
+				var player = await connection.GetAsync<PlayerData>(steamId);
 				if (player == null)
 					return -1;
 
@@ -153,7 +153,7 @@ public sealed partial class Plugin
 			}
 			catch (Exception ex)
 			{
-				Core.Logger.LogError(ex, "Failed to get rank position by time for {Steam}", visibleSteamId);
+				Core.Logger.LogError(ex, "Failed to get rank position by time for {Steam}", steamId);
 				return -1;
 			}
 		}

--- a/src-plugin/Plugin/Database/DatabaseService.Settings.cs
+++ b/src-plugin/Plugin/Database/DatabaseService.Settings.cs
@@ -20,7 +20,7 @@ public sealed partial class Plugin
 		// =           LOAD OPERATIONS
 		// =========================================
 
-		public async Task<PlayerSettings?> LoadPlayerSettingsAsync(string visibleSteamId)
+		public async Task<PlayerSettings?> LoadPlayerSettingsAsync(string steamId)
 		{
 			if (!IsEnabled)
 				return null;
@@ -30,11 +30,11 @@ public sealed partial class Plugin
 				using var connection = Core.Database.GetConnection(_connectionName);
 				connection.Open();
 
-				return await connection.GetAsync<PlayerSettings>(visibleSteamId);
+				return await connection.GetAsync<PlayerSettings>(steamId);
 			}
 			catch (Exception ex)
 			{
-				Core.Logger.LogError(ex, "Failed to load settings for {Steam}", visibleSteamId);
+				Core.Logger.LogError(ex, "Failed to load settings for {Steam}", steamId);
 				return null;
 			}
 		}
@@ -43,14 +43,14 @@ public sealed partial class Plugin
 		// =           SAVE OPERATIONS
 		// =========================================
 
-		public async Task SavePlayerSettingsAsync(string visibleSteamId, PlayerSettings settings)
+		public async Task SavePlayerSettingsAsync(string steamId, PlayerSettings settings)
 		{
 			if (!IsEnabled)
 				return;
 
 			try
 			{
-				settings.Steam = visibleSteamId;
+				settings.Steam = steamId;
 
 				using var connection = Core.Database.GetConnection(_connectionName);
 				connection.Open();
@@ -68,7 +68,7 @@ public sealed partial class Plugin
 			}
 			catch (Exception ex)
 			{
-				Core.Logger.LogError(ex, "Failed to save settings for {Steam}", visibleSteamId);
+				Core.Logger.LogError(ex, "Failed to save settings for {Steam}", steamId);
 			}
 		}
 

--- a/src-plugin/Plugin/Database/DatabaseService.WeaponStats.cs
+++ b/src-plugin/Plugin/Database/DatabaseService.WeaponStats.cs
@@ -18,7 +18,7 @@ public sealed partial class Plugin
 		// =           LOAD OPERATIONS
 		// =========================================
 
-		public async Task<List<WeaponStatRecord>> LoadWeaponStatsAsync(string visibleSteamId)
+		public async Task<List<WeaponStatRecord>> LoadWeaponStatsAsync(string steamId)
 		{
 			if (!IsEnabled || !_modules.WeaponStatsEnabled)
 				return [];
@@ -28,12 +28,12 @@ public sealed partial class Plugin
 				using var connection = Core.Database.GetConnection(_connectionName);
 				connection.Open();
 
-				var result = await connection.SelectAsync<WeaponStatRecord>(w => w.Steam == visibleSteamId);
+				var result = await connection.SelectAsync<WeaponStatRecord>(w => w.Steam == steamId);
 				return [.. result];
 			}
 			catch (Exception ex)
 			{
-				Core.Logger.LogError(ex, "Failed to load weapon stats for {Steam}", visibleSteamId);
+				Core.Logger.LogError(ex, "Failed to load weapon stats for {Steam}", steamId);
 				return [];
 			}
 		}
@@ -42,7 +42,7 @@ public sealed partial class Plugin
 		// =           SAVE OPERATIONS
 		// =========================================
 
-		public async Task SaveWeaponStatsAsync(string visibleSteamId, IEnumerable<WeaponStat> stats)
+		public async Task SaveWeaponStatsAsync(string steamId, IEnumerable<WeaponStat> stats)
 		{
 			if (!IsEnabled || !_modules.WeaponStatsEnabled)
 				return;
@@ -60,7 +60,7 @@ public sealed partial class Plugin
 				{
 					var record = new WeaponStatRecord
 					{
-						Steam = visibleSteamId,
+						Steam = steamId,
 						Classname = stat.WeaponClassname,
 						Kills = stat.Kills,
 						Deaths = stat.Deaths,
@@ -84,7 +84,7 @@ public sealed partial class Plugin
 			}
 			catch (Exception ex)
 			{
-				Core.Logger.LogError(ex, "Failed to save weapon stats for {Steam}", visibleSteamId);
+				Core.Logger.LogError(ex, "Failed to save weapon stats for {Steam}", steamId);
 			}
 		}
 	}

--- a/src-plugin/Plugin/Database/DatabaseService.cs
+++ b/src-plugin/Plugin/Database/DatabaseService.cs
@@ -95,28 +95,28 @@ public sealed partial class Plugin
 			}
 		}
 
-		public async Task ResetPlayerAsync(string visibleSteamId)
+		public async Task ResetPlayerAsync(string steamId)
 		{
 			if (!IsEnabled)
 				return;
 
 			try
 			{
-				await ResetPlayerStatsAsync(visibleSteamId);
-				await ResetPlayerModuleDataAsync(visibleSteamId);
+				await ResetPlayerStatsAsync(steamId);
+				await ResetPlayerModuleDataAsync(steamId);
 			}
 			catch (Exception ex)
 			{
-				Core.Logger.LogError(ex, "Failed to reset player {Steam}", visibleSteamId);
+				Core.Logger.LogError(ex, "Failed to reset player {Steam}", steamId);
 			}
 		}
 
-		private async Task ResetPlayerStatsAsync(string visibleSteamId)
+		private async Task ResetPlayerStatsAsync(string steamId)
 		{
 			using var connection = Core.Database.GetConnection(_connectionName);
 			connection.Open();
 
-			var player = await connection.GetAsync<PlayerData>(visibleSteamId);
+			var player = await connection.GetAsync<PlayerData>(steamId);
 			if (player == null)
 				return;
 
@@ -141,19 +141,19 @@ public sealed partial class Plugin
 			await connection.UpdateAsync(player);
 		}
 
-		private async Task ResetPlayerModuleDataAsync(string visibleSteamId)
+		private async Task ResetPlayerModuleDataAsync(string steamId)
 		{
 			using var connection = Core.Database.GetConnection(_connectionName);
 			connection.Open();
 
 			if (_modules.WeaponStatsEnabled)
 			{
-				await connection.DeleteMultipleAsync<WeaponStatRecord>(w => w.Steam == visibleSteamId);
+				await connection.DeleteMultipleAsync<WeaponStatRecord>(w => w.Steam == steamId);
 			}
 
 			if (_modules.HitStatsEnabled)
 			{
-				var hitData = await connection.GetAsync<HitData>(visibleSteamId);
+				var hitData = await connection.GetAsync<HitData>(steamId);
 				if (hitData != null)
 				{
 					await connection.DeleteAsync(hitData);

--- a/src-plugin/Plugin/Database/Migrations/M004_ExtendNameColumn.cs
+++ b/src-plugin/Plugin/Database/Migrations/M004_ExtendNameColumn.cs
@@ -1,0 +1,24 @@
+using FluentMigrator;
+
+namespace K4Ranks.Database.Migrations;
+
+/// <summary>
+/// Extends the 'name' column from VARCHAR(64) to VARCHAR(128).
+/// ASCII art player names frequently exceed the original 64-character limit,
+/// causing the INSERT to fail and the player's rank to never be persisted.
+/// </summary>
+[Migration(20251201004)]
+public class M004_ExtendNameColumn : Migration
+{
+	public override void Up()
+	{
+		Alter.Table("lvl_base")
+			.AlterColumn("name").AsString(128).NotNullable().WithDefaultValue("");
+	}
+
+	public override void Down()
+	{
+		Alter.Table("lvl_base")
+			.AlterColumn("name").AsString(64).NotNullable().WithDefaultValue("");
+	}
+}

--- a/src-plugin/Plugin/Database/Migrations/M005_NameColumnUtf8mb4.cs
+++ b/src-plugin/Plugin/Database/Migrations/M005_NameColumnUtf8mb4.cs
@@ -1,0 +1,30 @@
+using FluentMigrator;
+
+namespace K4Ranks.Database.Migrations;
+
+/// <summary>
+/// Converts the 'name' column in lvl_base to utf8mb4 on MySQL/MariaDB.
+/// MySQL's default 'utf8' charset is actually utf8mb3, which only supports
+/// Basic Multilingual Plane characters (≤ U+FFFF). Player names containing
+/// characters outside the BMP — such as Mathematical Fraktur, emoji, or other
+/// supplementary Unicode — require utf8mb4 (true 4-byte UTF-8).
+/// PostgreSQL and SQLite already store all Unicode correctly, so no change is
+/// needed on those engines.
+/// </summary>
+[Migration(20251201005)]
+public class M005_NameColumnUtf8mb4 : Migration
+{
+	public override void Up()
+	{
+		IfDatabase("MySql5").Execute.Sql(
+			"ALTER TABLE `lvl_base` MODIFY COLUMN `name` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';"
+		);
+	}
+
+	public override void Down()
+	{
+		IfDatabase("MySql5").Execute.Sql(
+			"ALTER TABLE `lvl_base` MODIFY COLUMN `name` VARCHAR(128) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL DEFAULT '';"
+		);
+	}
+}

--- a/src-plugin/Plugin/Database/Migrations/M006_SteamIdToSteamId64.cs
+++ b/src-plugin/Plugin/Database/Migrations/M006_SteamIdToSteamId64.cs
@@ -1,0 +1,124 @@
+using System.Data;
+using FluentMigrator;
+using MySqlConnector;
+using Npgsql;
+
+namespace K4Ranks.Database.Migrations;
+
+/// <summary>
+/// Converts steam ID keys from STEAM_X:Y:Z format to SteamID64 string format
+/// across all lvl_base tables.
+/// </summary>
+[Migration(20251201006)]
+public class M006_SteamIdToSteamId64 : Migration
+{
+	// Table name → steam column name
+	private static readonly (string Table, string Column)[] Tables =
+	[
+		("lvl_base",          "steam"),
+		("lvl_base_settings", "steam"),
+		("lvl_base_weapons",  "steam"),
+		("lvl_base_hits",     "SteamID"),
+	];
+
+	public override void Up()
+	{
+		Execute.WithConnection((connection, transaction) =>
+		{
+			bool isMySql   = connection is MySqlConnection;
+			bool isPostgres = connection is NpgsqlConnection;
+
+			foreach (var (table, column) in Tables)
+			{
+				if (!TableExists(connection, transaction, table, isMySql, isPostgres))
+					continue;
+
+				var sql = BuildConvertSql(table, column, isMySql, isPostgres);
+
+				using var cmd = connection.CreateCommand();
+				cmd.Transaction = transaction;
+				cmd.CommandText = sql;
+				cmd.ExecuteNonQuery();
+			}
+		});
+	}
+
+	public override void Down()
+	{
+		// Conversion back to STEAM_X:Y:Z is not feasible in pure SQL.
+		// Down migration is intentionally left empty.
+	}
+
+	private static bool TableExists(
+		IDbConnection connection,
+		IDbTransaction? transaction,
+		string table,
+		bool isMySql,
+		bool isPostgres)
+	{
+		string sql = isMySql || isPostgres
+			? $"SELECT COUNT(*) FROM information_schema.tables WHERE table_name = '{table}'"
+			: $"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='{table}'";
+
+		using var cmd = connection.CreateCommand();
+		cmd.Transaction = transaction;
+		cmd.CommandText = sql;
+
+		return Convert.ToInt64(cmd.ExecuteScalar()) > 0;
+	}
+
+	/// <summary>
+	/// Builds the UPDATE statement that converts STEAM_X:Y:Z values to SteamID64.
+	/// Formula: SteamID64 = 76561197960265728 + Z*2 + Y
+	///   where STEAM_X:Y:Z — Y is auth bit, Z is account number.
+	/// Only rows whose column still matches the STEAM_ prefix are touched.
+	/// </summary>
+	private static string BuildConvertSql(string table, string column, bool isMySql, bool isPostgres)
+	{
+		if (isMySql)
+		{
+			// SUBSTRING_INDEX is MySQL-specific
+			return
+				$"UPDATE `{table}` " +
+				$"SET `{column}` = CAST(" +
+				$"  76561197960265728 " +
+				$"  + CAST(SUBSTRING_INDEX(`{column}`, ':', -1) AS UNSIGNED) * 2 " +
+				$"  + CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(`{column}`, ':', 2), ':', -1) AS UNSIGNED) " +
+				$"  AS CHAR) " +
+				$"WHERE `{column}` LIKE 'STEAM_%'";
+		}
+
+		if (isPostgres)
+		{
+			// split_part is PostgreSQL-specific
+			return
+				$"UPDATE \"{table}\" " +
+				$"SET \"{column}\" = (" +
+				$"  76561197960265728 " +
+				$"  + CAST(split_part(\"{column}\", ':', 3) AS BIGINT) * 2 " +
+				$"  + CAST(split_part(\"{column}\", ':', 2) AS BIGINT)" +
+				$")::TEXT " +
+				$"WHERE \"{column}\" LIKE 'STEAM_%'";
+		}
+
+		// SQLite — use nested INSTR/SUBSTR
+		// For 'STEAM_X:Y:Z':
+		//   c1  = position of first ':'
+		//   c2r = position of second ':' relative to the substring after c1
+		//   Y   = character(s) between c1 and c2 relative to start
+		//   Z   = everything after c2
+		return
+			$"UPDATE \"{table}\" " +
+			$"SET \"{column}\" = CAST(" +
+			$"  76561197960265728 " +
+			$"  + CAST(SUBSTR(\"{column}\", " +
+			$"      INSTR(\"{column}\", ':') + " +
+			$"      INSTR(SUBSTR(\"{column}\", INSTR(\"{column}\", ':') + 1), ':') + 1) AS INTEGER) * 2 " +
+			$"  + CAST(SUBSTR(" +
+			$"      SUBSTR(\"{column}\", INSTR(\"{column}\", ':') + 1), " +
+			$"      1, " +
+			$"      INSTR(SUBSTR(\"{column}\", INSTR(\"{column}\", ':') + 1), ':') - 1) AS INTEGER) " +
+			$"  AS TEXT) " +
+			$"WHERE \"{column}\" LIKE 'STEAM_%'";
+	}
+}

--- a/src-plugin/Plugin/Events/Events.cs
+++ b/src-plugin/Plugin/Events/Events.cs
@@ -126,6 +126,7 @@ public sealed partial class Plugin
 
 	private void RegisterRoundEvents()
 	{
+		Core.GameEvent.HookPost<EventRoundPrestart>(OnRoundPrestart);
 		Core.GameEvent.HookPost<EventRoundStart>(OnRoundStart);
 		Core.GameEvent.HookPost<EventRoundEnd>(OnRoundEnd);
 	}
@@ -163,10 +164,17 @@ public sealed partial class Plugin
 		{
 			await PlayerData.SavePlayerDataAsync(steamId);
 			PlayerData.RemovePlayer(steamId);
+			Scoreboard.RemoveCachedRank(steamId);
 		});
 	}
 
 	/* ==================== Round Events ==================== */
+
+	private HookResult OnRoundPrestart(EventRoundPrestart @event)
+	{
+		Scoreboard.UpdateAllScoreboards();
+		return HookResult.Continue;
+	}
 
 	private HookResult OnRoundStart(EventRoundStart @event)
 	{

--- a/src-plugin/Plugin/Models/PlayerData.cs
+++ b/src-plugin/Plugin/Models/PlayerData.cs
@@ -15,7 +15,7 @@ public sealed class PlayerData
 	// =    LVL RANKS COMPATIBLE FIELDS
 	// =========================================
 
-	/// <summary>Steam ID in STEAM_X:X:XXXXXX format (stored as string in DB)</summary>
+	/// <summary>SteamID64 in decimal string form (e.g. "76561198XXXXXXXXX"), stored as the primary key in DB</summary>
 	[Key]
 	[DatabaseGenerated(DatabaseGeneratedOption.None)]
 	[Column("steam")]
@@ -109,8 +109,9 @@ public sealed class PlayerData
 	// =    RUNTIME DATA (NOT IN DB)
 	// =========================================
 
+	/// <summary>SteamID64 parsed from the <see cref="Steam"/> key; 0 if Steam is not yet set.</summary>
 	[Ignore]
-	public ulong SteamId64 { get; set; }
+	public ulong SteamId64 => ulong.TryParse(Steam, out var id) ? id : 0;
 	[Ignore]
 	public int RoundPoints { get; set; }
 	[Ignore]
@@ -181,7 +182,7 @@ public sealed class PlayerData
 	// =========================================
 
 	[Ignore]
-	public int Points { get => Value; set => Value = value; }
+	public int Points { get => Value; set => Value = Math.Max(0, value); }
 	[Ignore]
 	public string PlayerName { get => Name; set => Name = value; }
 	[Ignore]

--- a/src-plugin/Plugin/Plugin.cs
+++ b/src-plugin/Plugin/Plugin.cs
@@ -10,7 +10,7 @@ namespace K4Ranks;
 
 [PluginMetadata(
 	Id = "k4.levelranks",
-	Version = "1.1.1",
+	Version = "1.2.0",
 	Name = "K4 - Level Ranks",
 	Author = "K4ryuu",
 	Description = "Experience-based ranking system with configurable ranks, detailed player statistics, weapon tracking, and hit analysis for CS2."

--- a/src-plugin/Plugin/Services/PlayerDataService.cs
+++ b/src-plugin/Plugin/Services/PlayerDataService.cs
@@ -86,7 +86,7 @@ public sealed partial class Plugin
 				{
 					Steam = visibleSteamId,
 					SteamId64 = steamId64,
-					Name = player?.Controller?.PlayerName ?? "Unknown",
+					Name = SanitizeName(player?.Controller?.PlayerName),
 					Value = startPoints,
 					Rank = _plugin.Ranks.GetRankId(startPoints),
 					IsLoaded = true,
@@ -95,11 +95,36 @@ public sealed partial class Plugin
 			}
 
 			data.SteamId64 = steamId64;
-			data.Name = player?.Controller?.PlayerName ?? data.Name;
+			data.Name = SanitizeName(player?.Controller?.PlayerName) ?? data.Name;
 			data.Rank = _plugin.Ranks.GetRankId(data.Points);
 			data.IsLoaded = true;
 
 			return data;
+		}
+
+		/// <summary>
+		/// Sanitizes a player name for safe database storage.
+		/// Removes null bytes (rejected by MySQL VARCHAR columns regardless of charset)
+		/// and truncates to the maximum column length.
+		/// Supplementary Unicode characters (code points > U+FFFF) such as Mathematical
+		/// Fraktur, emoji, and other non-BMP scripts are preserved — the name column
+		/// uses utf8mb4 (see M005_NameColumnUtf8mb4) which supports the full Unicode range.
+		/// </summary>
+		private static string? SanitizeName(string? name)
+		{
+			if (string.IsNullOrEmpty(name))
+				return null;
+
+			var sb = new System.Text.StringBuilder(name.Length);
+			foreach (var c in name)
+			{
+				if (c == '\0') continue;               // null byte – MySQL VARCHAR rejects this
+				sb.Append(c);
+			}
+
+			const int MaxNameLength = 128;             // must match M004_ExtendNameColumn
+			var result = sb.ToString();
+			return result.Length > MaxNameLength ? result[..MaxNameLength] : result;
 		}
 
 		private async Task LoadPlayerSettings(PlayerData data, string visibleSteamId)

--- a/src-plugin/Plugin/Services/PlayerDataService.cs
+++ b/src-plugin/Plugin/Services/PlayerDataService.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using SwiftlyS2.Shared.Players;
-using SwiftlyS2.Shared.SteamAPI;
 
 namespace K4Ranks;
 
@@ -39,21 +38,21 @@ public sealed partial class Plugin
                 return;
 
             var steamId64 = player.SteamID;
-			var visibleSteamId = SteamIdParser.ToSteamId(steamId64);
+			var steamId = steamId64.ToString();
 
 			try
 			{
-				var data = await LoadOrCreatePlayerData(player, steamId64, visibleSteamId);
+				var data = await LoadOrCreatePlayerData(player, steamId64);
 
 				if (data == null)
 				{
-					Core.Logger.LogWarning("Failed to load or create player data for {Steam}. Player disconnected before data could be loaded", visibleSteamId);
+					Core.Logger.LogWarning("Failed to load or create player data for {Steam}. Player disconnected before data could be loaded", steamId);
                     return;
 				}
 
-					await LoadPlayerSettings(data, visibleSteamId);
-				var weaponStatsCount = await LoadWeaponStats(data, visibleSteamId);
-				await LoadHitData(data, visibleSteamId);
+					await LoadPlayerSettings(data, steamId);
+				var weaponStatsCount = await LoadWeaponStats(data, steamId);
+				await LoadHitData(data, steamId);
 
 				_playerData[steamId64] = data;
 
@@ -68,24 +67,24 @@ public sealed partial class Plugin
 			}
 			catch (Exception ex)
 			{
-				Core.Logger.LogError(ex, "Failed to load player data for {Steam}", visibleSteamId);
+				Core.Logger.LogError(ex, "Failed to load player data for {Steam}", steamId);
 			}
 		}
 
-		private async Task<PlayerData?> LoadOrCreatePlayerData(IPlayer? player, ulong steamId64, string visibleSteamId)
+		private async Task<PlayerData?> LoadOrCreatePlayerData(IPlayer? player, ulong steamId64)
 		{
             if (player == null || !player.IsValid)
                 return null;
 
-            var data = await _plugin.Database.LoadPlayerAsync(visibleSteamId);
+            var steamId = steamId64.ToString();
+            var data = await _plugin.Database.LoadPlayerAsync(steamId);
 
 			if (data == null)
 			{
 				var startPoints = _plugin.Config.CurrentValue.Rank.StartPoints;
 				return new PlayerData
 				{
-					Steam = visibleSteamId,
-					SteamId64 = steamId64,
+					Steam = steamId,
 					Name = SanitizeName(player?.Controller?.PlayerName),
 					Value = startPoints,
 					Rank = _plugin.Ranks.GetRankId(startPoints),
@@ -94,7 +93,6 @@ public sealed partial class Plugin
 				};
 			}
 
-			data.SteamId64 = steamId64;
 			data.Name = SanitizeName(player?.Controller?.PlayerName) ?? data.Name;
 			data.Rank = _plugin.Ranks.GetRankId(data.Points);
 			data.IsLoaded = true;
@@ -127,30 +125,30 @@ public sealed partial class Plugin
 			return result.Length > MaxNameLength ? result[..MaxNameLength] : result;
 		}
 
-		private async Task LoadPlayerSettings(PlayerData data, string visibleSteamId)
+		private async Task LoadPlayerSettings(PlayerData data, string steamId)
 		{
-			var settings = await _plugin.Database.LoadPlayerSettingsAsync(visibleSteamId);
-			data.Settings = settings ?? new PlayerSettings { Steam = visibleSteamId };
+			var settings = await _plugin.Database.LoadPlayerSettingsAsync(steamId);
+			data.Settings = settings ?? new PlayerSettings { Steam = steamId };
 		}
 
-		private async Task<int> LoadWeaponStats(PlayerData data, string visibleSteamId)
+		private async Task<int> LoadWeaponStats(PlayerData data, string steamId)
 		{
 			if (!_plugin.Modules.CurrentValue.WeaponStatsEnabled)
 				return 0;
 
-			var weaponStats = await _plugin.Database.LoadWeaponStatsAsync(visibleSteamId);
+			var weaponStats = await _plugin.Database.LoadWeaponStatsAsync(steamId);
 			data.WeaponStats.LoadFrom(weaponStats);
 
 			return weaponStats.Count;
 		}
 
-		private async Task LoadHitData(PlayerData data, string visibleSteamId)
+		private async Task LoadHitData(PlayerData data, string steamId)
 		{
 			if (!_plugin.Modules.CurrentValue.HitStatsEnabled)
 				return;
 
-			var hitData = await _plugin.Database.LoadHitDataAsync(visibleSteamId);
-			data.HitData = hitData ?? new HitData { Steam = visibleSteamId };
+			var hitData = await _plugin.Database.LoadHitDataAsync(steamId);
+			data.HitData = hitData ?? new HitData { Steam = steamId };
 		}
 
 		/* ==================== Save ==================== */

--- a/src-plugin/Plugin/Services/ScoreboardService.cs
+++ b/src-plugin/Plugin/Services/ScoreboardService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using SwiftlyS2.Shared;
 using SwiftlyS2.Shared.Players;
 using SwiftlyS2.Shared.ProtobufDefinitions;
@@ -14,6 +15,81 @@ public sealed class ScoreboardService(Plugin plugin)
 	private readonly ISwiftlyCore _core = Plugin.Core;
 	private bool _isRunning;
 
+	/// <summary>
+	/// Per-player virtual point overrides.
+	/// When set, both the displayed rank icon and the displayed point value are
+	/// derived from this virtual points figure rather than the player's real points.
+	/// The actual <see cref="PlayerData.Points"/> value is never modified.
+	/// </summary>
+	private readonly ConcurrentDictionary<ulong, int> _pointOverrides = new();
+
+	/// <summary>
+	/// Cached scoreboard values computed on <c>round_prestart</c> (or immediately
+	/// when an override is set). The tick handler reads this cache and writes it to
+	/// the controller every frame so the rank icon stays visible continuously.
+	/// </summary>
+	private readonly ConcurrentDictionary<ulong, (int RankId, int DisplayPoints)> _cachedRanks = new();
+
+	/* ==================== Rank Overrides ==================== */
+
+	/// <summary>
+	/// Virtually overrides the scoreboard-displayed rank and point value for a player.
+	/// Both the rank icon and the Premier-mode point number shown in the CS2 scoreboard
+	/// are derived from <paramref name="virtualPoints"/>. The player's actual
+	/// <see cref="PlayerData.Points"/> is never modified.
+	/// </summary>
+	/// <param name="steamId">64-bit Steam ID of the target player.</param>
+	/// <param name="virtualPoints">Virtual point value to display on the scoreboard.</param>
+	public void SetPointOverride(ulong steamId, int virtualPoints) =>
+		_pointOverrides[steamId] = virtualPoints;
+
+	/// <summary>
+	/// Removes a previously set virtual point override so the scoreboard reverts to
+	/// displaying the rank computed from the player's real points.
+	/// </summary>
+	public void ClearPointOverride(ulong steamId) =>
+		_pointOverrides.TryRemove(steamId, out _);
+
+	/// <summary>
+	/// Returns whether a virtual point override is active for the given player, and
+	/// the override value if so.
+	/// </summary>
+	public bool TryGetPointOverride(ulong steamId, out int virtualPoints) =>
+		_pointOverrides.TryGetValue(steamId, out virtualPoints);
+
+	/// <summary>
+	/// Removes the cached rank entry for a player. Call on disconnect to prevent
+	/// stale data accumulating in <see cref="_cachedRanks"/>.
+	/// </summary>
+	public void RemoveCachedRank(ulong steamId)
+	{
+		_cachedRanks.TryRemove(steamId, out _);
+		_pointOverrides.TryRemove(steamId, out _);
+	}
+
+	/* ==================== Per-Player Refresh ==================== */
+
+	/// <summary>
+	/// Recalculates and caches the effective scoreboard rank for a single player,
+	/// then applies it immediately. Use this after setting or clearing an override
+	/// so the icon updates without waiting for the next <c>round_prestart</c>.
+	/// </summary>
+	public void UpdatePlayerScoreboard(IPlayer player)
+	{
+		if (!plugin.Config.CurrentValue.Scoreboard.UseRanks)
+			return;
+
+		if (!player.IsValid || player.IsFakeClient)
+			return;
+
+		var data = plugin.PlayerData.GetPlayerData(player);
+		if (data == null || !data.IsLoaded)
+			return;
+
+		var cfg = plugin.Config.CurrentValue.Scoreboard;
+		CacheAndApplyScoreboardRank(player, data, cfg);
+	}
+
 	/* ==================== Start / Stop ==================== */
 
 	public void Start()
@@ -24,7 +100,7 @@ public sealed class ScoreboardService(Plugin plugin)
 		_isRunning = true;
 
 		if (plugin.Config.CurrentValue.Scoreboard.UseRanks)
-			_core.Event.OnTick += UpdateScoreboards;
+			_core.Event.OnTick += ApplyAllCachedScoreboards;
 
 		if (plugin.Config.CurrentValue.Scoreboard.RevealAllInterval > 0)
 			StartRevealAllTimer();
@@ -36,7 +112,7 @@ public sealed class ScoreboardService(Plugin plugin)
 			return;
 
 		_isRunning = false;
-		_core.Event.OnTick -= UpdateScoreboards;
+		_core.Event.OnTick -= ApplyAllCachedScoreboards;
 	}
 
 	/* ==================== Reveal All ==================== */
@@ -75,15 +151,17 @@ public sealed class ScoreboardService(Plugin plugin)
 
 	/* ==================== Scoreboard Updates ==================== */
 
-	private void UpdateScoreboards()
+	/// <summary>
+	/// Recalculates and caches the effective rank for every loaded player.
+	/// Called on <c>round_prestart</c> — rank values are computed once per round
+	/// and then replayed every tick by <see cref="ApplyAllCachedScoreboards"/>.
+	/// </summary>
+	public void UpdateAllScoreboards()
 	{
 		if (!plugin.Config.CurrentValue.Scoreboard.UseRanks)
 			return;
 
-		var mode = plugin.Config.CurrentValue.Scoreboard.RankMode;
-		var rankMax = plugin.Config.CurrentValue.Scoreboard.CustomRankMax;
-		var rankBase = plugin.Config.CurrentValue.Scoreboard.CustomRankBase;
-		var rankMargin = plugin.Config.CurrentValue.Scoreboard.CustomRankMargin;
+		var cfg = plugin.Config.CurrentValue.Scoreboard;
 
 		foreach (var player in _core.PlayerManager.GetAllPlayers())
 		{
@@ -94,9 +172,54 @@ public sealed class ScoreboardService(Plugin plugin)
 			if (data == null || !data.IsLoaded)
 				continue;
 
-			var rankId = plugin.Ranks.GetRankId(data.Points);
-			SetCompetitiveRank(player, mode, rankId, data.Points, rankMax, rankBase, rankMargin);
+			CacheAndApplyScoreboardRank(player, data, cfg);
 		}
+	}
+
+	/// <summary>
+	/// Tick handler — writes the cached rank values to every player's controller
+	/// fields so the rank icon remains visible every frame.
+	/// No rank recalculation happens here; that is done in
+	/// <see cref="UpdateAllScoreboards"/> on <c>round_prestart</c>.
+	/// </summary>
+	private void ApplyAllCachedScoreboards()
+	{
+		if (!plugin.Config.CurrentValue.Scoreboard.UseRanks)
+			return;
+
+		var cfg = plugin.Config.CurrentValue.Scoreboard;
+
+		foreach (var player in _core.PlayerManager.GetAllPlayers())
+		{
+			if (!player.IsValid || player.IsFakeClient)
+				continue;
+
+			if (!_cachedRanks.TryGetValue(player.SteamID, out var cached))
+				continue;
+
+			SetCompetitiveRank(player, cfg.RankMode, cached.RankId, cached.DisplayPoints,
+				cfg.CustomRankMax, cfg.CustomRankBase, cfg.CustomRankMargin);
+		}
+	}
+
+	/// <summary>
+	/// Computes the effective rank (real or virtual), stores it in the cache, and
+	/// applies it to the player's controller immediately.
+	/// When a virtual point override is active, both the rank icon and the
+	/// Premier-mode point number are derived from that override value.
+	/// </summary>
+	private void CacheAndApplyScoreboardRank(IPlayer player, PlayerData data, ScoreboardSettings cfg)
+	{
+		int effectivePoints = TryGetPointOverride(data.SteamId64, out var virtualPoints)
+			? virtualPoints
+			: data.Points;
+
+		int rankId = plugin.Ranks.GetRankId(effectivePoints);
+
+		_cachedRanks[data.SteamId64] = (rankId, effectivePoints);
+
+		SetCompetitiveRank(player, cfg.RankMode, rankId, effectivePoints,
+			cfg.CustomRankMax, cfg.CustomRankBase, cfg.CustomRankMargin);
 	}
 
 	private static void SetCompetitiveRank(

--- a/src-plugin/Plugin/Services/SharedApiService.cs
+++ b/src-plugin/Plugin/Services/SharedApiService.cs
@@ -1,6 +1,5 @@
 using K4RanksSharedApi;
 using SwiftlyS2.Shared.Players;
-using SwiftlyS2.Shared.SteamAPI;
 
 namespace K4Ranks;
 
@@ -133,8 +132,8 @@ public sealed partial class Plugin
 
 		public async Task<int> GetPlayerPositionAsync(IPlayer player)
 		{
-			var visibleSteamId = SteamIdParser.ToSteamId(player.SteamID);
-			return await _plugin.Database.GetPlayerRankPositionAsync(visibleSteamId);
+			var steamId = player.SteamID.ToString();
+			return await _plugin.Database.GetPlayerRankPositionAsync(steamId);
 		}
 
 		public async Task<int> GetTotalPlayersAsync()

--- a/src-plugin/Plugin/Services/SharedApiService.cs
+++ b/src-plugin/Plugin/Services/SharedApiService.cs
@@ -141,5 +141,29 @@ public sealed partial class Plugin
 		{
 			return await _plugin.Database.GetTotalPlayersAsync();
 		}
+
+		public void UpdatePlayerScoreboard(IPlayer player)
+		{
+			_plugin.Scoreboard.UpdatePlayerScoreboard(player);
+		}
+
+		public void SetScoreboardRankOverride(IPlayer player, int points)
+		{
+			_plugin.Scoreboard.SetPointOverride(player.SteamID, points);
+			_plugin.Scoreboard.UpdatePlayerScoreboard(player);
+		}
+
+		public void ClearScoreboardRankOverride(IPlayer player)
+		{
+			_plugin.Scoreboard.ClearPointOverride(player.SteamID);
+			_plugin.Scoreboard.UpdatePlayerScoreboard(player);
+		}
+
+		public int? GetScoreboardRankOverride(IPlayer player)
+		{
+			return _plugin.Scoreboard.TryGetPointOverride(player.SteamID, out var virtualPoints)
+				? virtualPoints
+				: null;
+		}
 	}
 }

--- a/src-plugin/Plugin/Stats/Events/PlayerHurtHandler.cs
+++ b/src-plugin/Plugin/Stats/Events/PlayerHurtHandler.cs
@@ -28,7 +28,7 @@ public sealed class PlayerHurtHandler(PluginConfig config, ModuleConfig modules,
 		var victim = @event.UserIdPlayer;
 
 		// Basic validation
-		if (!attacker.IsValid || !victim.IsValid)
+		if (attacker == null || !attacker.IsValid || !victim.IsValid)
 			return HookResult.Continue;
 
 		if (attacker.IsFakeClient)

--- a/src-shared/IK4RanksApi.cs
+++ b/src-shared/IK4RanksApi.cs
@@ -55,4 +55,37 @@ public interface IK4RanksApi
 	/// <summary>Get total number of ranked players.</summary>
 	/// <returns>The total number of players in the ranking system.</returns>
 	Task<int> GetTotalPlayersAsync();
+
+	// =========================================
+	// =       SCOREBOARD RANK DISPLAY
+	// =========================================
+
+	/// <summary>
+	/// Forces an immediate scoreboard rank refresh for the given player,
+	/// reflecting any active virtual override or their real rank if none is set.
+	/// </summary>
+	void UpdatePlayerScoreboard(IPlayer player);
+
+	/// <summary>
+	/// Virtually overrides the rank icon and point value shown for a player in the
+	/// CS2 scoreboard. Both the rank icon (all modes) and the Premier-mode point
+	/// number are derived from <paramref name="points"/>. The player's actual points,
+	/// stats, and database record are completely unaffected. The override is
+	/// session-only — it is never persisted and is cleared when the player disconnects.
+	/// </summary>
+	/// <param name="player">The target player.</param>
+	/// <param name="points">Virtual point value to display on the scoreboard.</param>
+	void SetScoreboardRankOverride(IPlayer player, int points);
+
+	/// <summary>
+	/// Clears a previously set virtual rank override so the scoreboard reverts to
+	/// showing the rank derived from the player's real points.
+	/// </summary>
+	void ClearScoreboardRankOverride(IPlayer player);
+
+	/// <summary>
+	/// Returns the active virtual point override for the player, or <c>null</c> if no
+	/// override is set and the real computed rank is being displayed.
+	/// </summary>
+	int? GetScoreboardRankOverride(IPlayer player);
 }


### PR DESCRIPTION
## Summary

This PR addresses crashes and data loss bugs, improves Unicode name handling, and extends the shared API with scoreboard display controls.

---

### Bug fixes

- **`NullReferenceException` on fall/environmental damage** — `PlayerHurtHandler` now null-checks the attacker before accessing `.IsValid`. Previously any damage with no player attacker (fall damage, `trigger_hurt`, etc.) crashed the event callback.
- **Player data not being persisted for special-character names** — Names exceeding the old 64-character `name` column limit silently failed the database INSERT, so the player's rank was never saved.

---

### Database migrations

| # | Migration | Change |
|---|-----------|--------|
| M004 | `M004_ExtendNameColumn` | Widens `lvl_base.name` from `VARCHAR(64)` → `VARCHAR(128)` |
| M005 | `M005_NameColumnUtf8mb4` | Converts `lvl_base.name` to `utf8mb4` on MySQL/MariaDB, enabling full Unicode support (emoji, Mathematical Fraktur, non-BMP scripts) |

A `SanitizeName` helper was added to `PlayerDataService` to strip null bytes (`\0`) and truncate to column width before any INSERT. The previous surrogate-pair filter is removed now that `utf8mb4` is in place.

---

### Scoreboard rank display

- Rank calculation is now split from rank presentation:
  - **`round_prestart`** — computes each player's effective rank and caches `(RankId, DisplayPoints)` per player
  - **`OnTick`** — reads the cache and writes to controller fields every frame (no recalculation)
- Added a **virtual point override** system to `ScoreboardService` and `IK4RanksApi`:
  - `SetScoreboardRankOverride(player, points)` — displays a rank derived from `points` without touching real `PlayerData.Points` or setting `IsDirty`
  - `ClearScoreboardRankOverride(player)` — restores the real rank immediately
  - `GetScoreboardRankOverride(player)` — returns the active virtual point value or `null`
  - Cached entries are evicted on player disconnect via `RemoveCachedRank`

---

### Build

- Excluded `runtimes/` folder from publish output via `<Content CopyToPublishDirectory="Never" />` and a `RemoveRuntimeFolders` MSBuild target, removing unnecessary native runtime directories from the distributed zip.